### PR TITLE
Manifest Additions + Per-View Generalization

### DIFF
--- a/litemark/init.lua
+++ b/litemark/init.lua
@@ -198,10 +198,10 @@ function NoteReadView:update_layout()
   end
   
   local text = self.doc:get_text(1, 1, #self.doc.lines, #self.doc.lines[#self.doc.lines])
-  local blocks = parser.parse_blocks(text)
+  local blocks = parser.parse_blocks(text, self.block_rules)
   
   -- Pass the reduced width to the layout engine
-  self.display_list = layout.compute(blocks, w)
+  self.display_list = layout.compute(blocks, w, { span_rules = self.span_rules })
   
   self._layout_ver = ver
   self._layout_w   = w
@@ -249,6 +249,8 @@ function NoteReadView:draw()
         renderer.draw_text(cmd.font, cmd.text, ox + cmd.x, oy + cmd.y, cmd.color)
       elseif cmd.type == TYPE.RECT then
         renderer.draw_rect(ox + cmd.x, oy + cmd.y, cmd.w, cmd.h, cmd.color)
+      elseif cmd.type == TYPE.CANVAS then
+        renderer.draw_canvas(cmd.canvas, ox + cmd.x, oy + cmd.y)
       end
     end
   end
@@ -424,3 +426,11 @@ contextmenu:register(function()
 end, {
   { text = "View Markdown", command = "litemark:view current markdown" }
 })
+
+return {
+  NoteReadView = NoteReadView,
+  NoteEditView = NoteEditView,
+  layout = layout,
+  config = config,
+  parser = parser
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "addons": [{
     "id": "litemark",
     "name": "LiteMark",
+    "mod_version": "3",
     "description": "A markdown previewer.",
     "version": "0.1",
     "path": "litemark"


### PR DESCRIPTION
- Adds a manifest.json, so that this plugin can be automatically installed with a package manager like https://github.com/lite-xl/lite-xl-plugin-manager.
- Generalizes rules, and exposes defaults to external plugins, so that a plugin can add a custom fenced block like so:

```lua
litemark.layout.draw_ops["jupyter-formula"] = function(ctx, block)
	ctx.y = ctx.y + litemark.layout.L.RULE_GAP_TOP

  table.insert(ctx.output, {
    type  = litemark.layout.DRAW_MODE.CANVAS,
    x     = litemark.layout.L.HEADER_MARGIN_LEFT,
    y     = ctx.y,
    w     = 300,
    h     = 200,
    canvas = block.canvas
  })

  ctx.y = ctx.y + litemark.layout.L.RULE_GAP_BOTTOM
end

table.insert(self.read_view.block_rules, 1, { "^%$%$", function(state, line)
		state.in_fence = "%$%$"
		table.insert(state.blocks, { 
			type  = "jupyter-formula", 
			lines = {}, 
			arg   = nil,
			close = function(blk)
				-- parse formula here, for now, place a blank canvas
				blk.size = { x = 300, y = 200 }
				blk.canvas = canvas.new(blk.size.x, blk.size.y)
			end
		})
		return true
  end  })
```